### PR TITLE
Dropped broken caching for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ dist: trusty
 services:
   - docker
 
-# Cache Ansible and Molecule to speed things up
-cache:
-  - pip
-
 install:
   # Install dependencies
   - ./moleculew wrapper-install


### PR DESCRIPTION
Due to the different versions required.