### PR TITLE
Increased minimum Ansible version to 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=centos
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=debian_max
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=debian_min
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=ubuntu_max
     - env:
-        - MOLECULEW_ANSIBLE=2.4.6
+        - MOLECULEW_ANSIBLE=2.5.10
         - MOLECULE_SCENARIO=ubuntu_min
     - env:
         - MOLECULEW_ANSIBLE=2.7.0

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ converting Docker Compose files to Kubernetes resources.
 Requirements
 ------------
 
-* Ansible >= 2.4
+* Ansible >= 2.5
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.5.