### PR TITLE
Increased minimum Ansible version to 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ env:
 matrix:
   include:
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=centos
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=debian_max
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=debian_min
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=ubuntu_max
     - env:
-        - MOLECULEW_ANSIBLE=2.5.10
+        - MOLECULEW_ANSIBLE=2.6.18
         - MOLECULE_SCENARIO=ubuntu_min
     - env:
         - MOLECULEW_ANSIBLE=2.8.2

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ converting Docker Compose files to Kubernetes resources.
 Requirements
 ------------
 
-* Ansible >= 2.5
+* Ansible >= 2.6
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: John Freeman
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.5
+  min_ansible_version: 2.6
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Ansible no longer supports versions earlier than 2.6.