### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ matrix:
         - MOLECULEW_ANSIBLE=2.9.1
         - MOLECULE_SCENARIO=ubuntu_min
 
-# Require the standard build environment
-sudo: required
-
 # Require Ubuntu 14.04
 dist: trusty
 


### PR DESCRIPTION
The key `sudo` has no effect anymore.