### PR TITLE
Dropped support for Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Requirements
 
         * Debian
 
-            * Stretch (9)
             * Buster (10)
             * Bullseye (11)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,6 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian_min/molecule.yml
+++ b/molecule/debian_min/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible_role_kompose_debian_min
-    image: debian:9
+    image: debian:10
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian ended LTS support on 01 Jul 2022.